### PR TITLE
Add sd-utils to patterns

### DIFF
--- a/patterns/jolla-hw-adaptation-geminipda.yaml
+++ b/patterns/jolla-hw-adaptation-geminipda.yaml
@@ -84,5 +84,8 @@ Requires:
 # For suspend to work with enabled Wi-Fi on MediaTek devices
 - sailfish-connman-plugin-suspend-wmtwifi
 
+# Mount SD-Card and OTG USB drives
+- sd-utils
+
 Summary: Jolla HW Adaptation geminipda
 


### PR DESCRIPTION
This will drag in udisks2 and friends. There are udev rules to mount sd cards and USB drives.